### PR TITLE
Pass "encoding" and "contype" to "field" event

### DIFF
--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -254,7 +254,7 @@ function Multipart(boy, cfg) {
           curField = undefined;
           if (buffer.length)
             buffer = decodeText(buffer, 'binary', charset);
-          boy.emit('field', fieldname, buffer, false, truncated);
+          boy.emit('field', fieldname, buffer, false, truncated, encoding, contype);
           --nends;
           checkFinished();
         };


### PR DESCRIPTION
This PR adds the arguments `contype` (Content-Type) and `encoding` to the `field` event, there are already passed to the `file` event.